### PR TITLE
Build/run services with the same openjdk version

### DIFF
--- a/authcodews/Dockerfile
+++ b/authcodews/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11 AS build
+FROM openjdk:11.0.7 AS build
 
 RUN apt-get update && apt-get install -y maven
 WORKDIR /build/

--- a/backendws/Dockerfile
+++ b/backendws/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11 AS build
+FROM openjdk:11.0.7 AS build
 
 RUN apt-get update && apt-get install -y maven
 WORKDIR /build/


### PR DESCRIPTION
As of this commit, it was being built with version `11.0.8` and ran with `11.0.7`